### PR TITLE
fix: handle kaleido browser detection better

### DIFF
--- a/changelog.d/1.bugfix.md
+++ b/changelog.d/1.bugfix.md
@@ -1,0 +1,2 @@
+Improve handling of kaleido browser detection failures in the cli, providing
+feedback only when trying to export a graph to an image.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,8 @@ class TestCli:
             mock.patch(
                 "plotly.graph_objects.Figure.write_image", autospec=True
             ) as self.mock_write_image,
+            # tests should be runnable without requiring a Chrome browser installation
+            mock.patch("pyright_analysis.cli._kaleido_configured", new=True),
         ):
             yield
 
@@ -136,6 +138,15 @@ class TestCli:
         self.mock_write_image.assert_called_once()
         call = self.mock_write_image.call_args
         assert call.args[1].name == "foobar.png"
+
+    def test_image_command_no_chromium(self) -> None:
+        with mock.patch("pyright_analysis.cli._kaleido_configured", new=False):
+            result = self.invoke("image", pipe_report=True)
+            assert result.exit_code == 2
+            assert (
+                "Image rendering requires a Chromium-based browser installation"
+                in result.output
+            )
 
     def test_image_command_filename_extension_ignores_format(self) -> None:
         result = self.invoke(


### PR DESCRIPTION
Importing the Plotly kaleido scope for image defaults triggers a search for a Chromium based browser, that, when it fails, stops all cli commands from loading. Handle this error better by replacing the defaults with `None` values and provide a more user-friendly version of the error feedback when trying to export an image.

Fixes #1
