### PR TITLE
chore: Attach release attestations to GitHub repo

### DIFF
--- a/.github/scripts/attestations_report.jq
+++ b/.github/scripts/attestations_report.jq
@@ -1,0 +1,11 @@
+# Convert an array of {id, filename, url} entries into a Markdown-formatted report
+[
+    "### Attestations Created",
+    "",
+    (
+        .[] | " * [\(.filename)](\(.url))"
+    ),
+    "", 
+    "Verify with `gh attestation verify --repo \($repo) --predicate-type https://docs.pypi.org/attestations/publish/v1 [FILENAME]`"
+]
+| join("\n")

--- a/.github/scripts/convert_attestations_to_sigstore.py
+++ b/.github/scripts/convert_attestations_to_sigstore.py
@@ -1,0 +1,43 @@
+# Convert PEP 740 attestations to Sigstore bundles
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#   "pypi-attestations==0.0.20"
+# ]
+# [tool.uv]
+# prerelease = "allow"  # necessary for sigstore dependencies
+# exclude-newer = "2024-12-30T13:21:53Z"
+# ///
+
+import argparse
+import io
+from collections.abc import Sequence
+from pathlib import Path
+
+from pypi_attestations import Attestation
+
+
+def main(argv: Sequence[str]) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("attestations", nargs="+", type=argparse.FileType("r"))
+    args = parser.parse_args(argv)
+
+    here = Path.cwd()
+
+    attestation_file: io.TextIOWrapper[io.BufferedReader]
+    for attestation_file in args.attestations:
+        from_ = Path(str(attestation_file.name)).resolve()
+        base = from_.with_name(from_.stem)  # strip .attestation
+        to_ = base.with_suffix(".sigstore")  # replaces .publish suffix
+        print(f"Converting {from_.relative_to(here)} to {to_.relative_to(here)}")
+        with attestation_file as source:
+            attestation = Attestation.model_validate_json(source.read())
+        sigstore_bundle = attestation.to_bundle()
+        with to_.open("w") as dest:
+            dest.write(sigstore_bundle.to_json())
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1:])

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -10,6 +10,8 @@ on:
 env:
   FORCE_COLOR: 1
 
+permissions:
+  contents: read
 
 jobs:
   linting:
@@ -177,6 +179,7 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
       contents: write  # required for creating GH releases
+      attestations: write  # required for uploading sigstore attestations to the Github API
     steps:
     - name: Download Python 🐍 distribution 📦
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -185,10 +188,63 @@ jobs:
 
     - name: Publish Python 🐍 distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
+    
+    - name: Install uv
+      uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5.1.0
+      with:
+        enable-cache: true
+        cache-dependency-glob: .github/scripts/convert_attestations_to_sigstore.py
+    
+    - name: Convert attestations to sigstore bundles
+      run: |
+        uv run .github/scripts/convert_attestations_to_sigstore.py dist/*.attestation
+    
+    - name: Upload attestations to GitHub and summarise
+      id: github-attestations
+      run: |
+        per_attestation=()
+        for bundle in dist/*.sigstore; do
+          filename="$(basename "${bundle%.sigstore}")"
+          attestation_id=$(
+            jq -c '{"bundle":.}' "$bundle" \
+              | gh api \
+                --method POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                '/repos/{owner}/{repo}/attestations' \
+                --input \
+                --jq '.id'
+          )
+          # collate information into a JSON object per attestation
+          per_attestation+=( "$(
+            jq --null-input --compact-output \
+              --arg attestation_id "$attestation_id" \
+              --arg filename "$filename" \
+              --arg server_url "$GITHUB_SERVER_URL" \
+              --arg repository "$GITHUB_REPOSITORY" \
+              '{filename: $filename, id: $attestation_id, url: "\($server_url)/\($repository)/attestations/\($attestation_id)"}'
+          )" )
+        done
+        # collate the per-attestation JSON object into an array, and share it as step output
+        attestations="$(jq '[$ARGS.positional[]]' --compact-output --null-input --jsonargs "${per_attestation[@]}")"
+        echo "attestations=${attestations}" >> "$GITHUB_OUTPUT"
+
+        # extend the release notes with a thematic break to separate the attestations report
+        {
+          echo
+          echo '---'
+          echo
+        } >> release_notes.md
+
+        # generate a summary for both the release notes and the step output
+        echo "$attestations" \
+          | jq --raw-output --arg repo "$GITHUB_REPOSITORY" --from-file .github/scripts/attestations_report.jq \
+          | tee -a release_notes.md $GITHUB_STEP_SUMMARY
 
     - name: GitHub release
       uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
       with:
         name: Pyright Analysis ${{ needs.build.outputs.version }}
+        bodyFile: release_notes.md
         artifacts: dist/*
         prerelease: ${{ needs.build.outputs.prerelease }}


### PR DESCRIPTION
The PyPI attestions can be converted to the sigstore format, a format that Github accepts directly (normally via the actions/attest action).  Push the sigstore attestations to GitHub for additional verification options and report these on the step output and release page.
