### PR TITLE
fix: Correct image format selection

### DIFF
--- a/changelog.d/24.bugfix.md
+++ b/changelog.d/24.bugfix.md
@@ -1,0 +1,1 @@
+Fix format selection for image exports with an explicit filename.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ branch = true
 exclude_also = [
     "if TYPE_CHECKING:",
     "return NotImplemented",
+    "@overload",
 ]
 show_missing = true
 


### PR DESCRIPTION
When setting an output filename, `figure.write_image` is passed an open fileobject and so it'd never select a format based on the filename extension. Explicitly set a format when none has been seleceted, and don't try to second-guess the user when a format has been passed in that conflicts with the filename.

Fixes #24
