### PR TITLE
chore: Check out before dowloading

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -188,6 +188,8 @@ jobs:
       CONVERT_TO_SIGSTORE: .github/scripts/convert_attestations_to_sigstore.py
 
     steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
     - name: Download Python 🐍 distribution 📦
       uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
@@ -195,8 +197,6 @@ jobs:
 
     - name: Publish Python 🐍 distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 # v1.12.3
-
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Install uv
       uses: astral-sh/setup-uv@887a942a15af3a7626099df99e897a18d9e5ab3a # v5.1.0


### PR DESCRIPTION
The checkout step _deletes_ everything in the working area, so run this before downloading the built packages.
